### PR TITLE
Feature/authenticate user

### DIFF
--- a/src/handlers/user.ts
+++ b/src/handlers/user.ts
@@ -1,6 +1,6 @@
 import prisma from "../db";
 import { Request, Response } from "express";
-import { createJWT, hashPassword } from "../modules/auth";
+import { comparePassword, createJWT, hashPassword } from "../modules/auth";
 import { User } from "../types/user.type";
 
 export const createNewUser = async (req: Request & User, res: Response) => {
@@ -10,6 +10,34 @@ export const createNewUser = async (req: Request & User, res: Response) => {
       password: await hashPassword(req.body.password),
     },
   });
+
+  const token = createJWT(user);
+  res.json({ token });
+};
+
+export const signin = async (req: Request & User, res: Response) => {
+  const user = await prisma.user.findUnique({
+    where: {
+      username: req.body.username,
+    },
+  });
+
+  const isValid = await comparePassword(
+    req.body.password,
+    user?.password ?? "",
+  );
+
+  if (!isValid) {
+    res.status(401);
+    res.json({ message: "비밀번호가 일치하지 않습니다." });
+    return;
+  }
+
+  if (!user) {
+    res.status(401);
+    res.json({ message: "아이디가 잘못되었어요." });
+    return;
+  }
 
   const token = createJWT(user);
   res.json({ token });

--- a/src/handlers/user.ts
+++ b/src/handlers/user.ts
@@ -1,9 +1,9 @@
 import prisma from "../db";
 import { Request, Response } from "express";
 import { comparePassword, createJWT, hashPassword } from "../modules/auth";
-import { User } from "../types/user.type";
+import type { User } from "@prisma/client";
 
-export const createNewUser = async (req: Request & User, res: Response) => {
+export const createNewUser = async (req: Request<User>, res: Response) => {
   const user = await prisma.user.create({
     data: {
       username: req.body.username,
@@ -15,7 +15,7 @@ export const createNewUser = async (req: Request & User, res: Response) => {
   res.json({ token });
 };
 
-export const signin = async (req: Request & User, res: Response) => {
+export const signin = async (req: Request<User>, res: Response) => {
   const user = await prisma.user.findUnique({
     where: {
       username: req.body.username,

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -18,7 +18,7 @@ export const createJWT = (user: User) => {
       id: user.id,
       username: user.username,
     },
-    process.env.JWT_TOKEN ?? "",
+    process.env.JWT_SECRET || "",
   );
   return token;
 };

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -1,7 +1,7 @@
 import jwt, { JwtPayload } from "jsonwebtoken";
 import { NextFunction, Request, Response } from "express";
 import bcrypt from "bcrypt";
-import { User } from "../types/user.type";
+import type { User } from "@prisma/client";
 
 export const comparePassword = (password: string | Buffer, hash: string) => {
   return bcrypt.compare(password, hash);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,10 +2,15 @@ import express from "express";
 import router from "./routes";
 import morgan from "morgan";
 import { protect } from "./modules/auth";
+import { createNewUser, signin } from "./handlers/user";
 
 const app = express();
+app.use(express.json());
 app.use(morgan("dev"));
 
-app.use("/", protect, router);
+app.use("/api", protect, router);
+
+app.post("/user", createNewUser);
+app.post("/signin", signin);
 
 export default app;


### PR DESCRIPTION
## Make Public Routes Handler

These apis are public so that user can request without token. Any other apis that start with 'api/' endpoint are private which require access token. 

1. [Make signin function](https://github.com/ahcock/eosi-api/commit/4c548d00a4b92b866d91719be4fb020800585914)
2. [Make signin, signup post route](https://github.com/ahcock/eosi-api/commit/3dce572244ef93d6692d9e730e02c45ef43c1774)

## Chore

1. [Change referencing User type](https://github.com/ahcock/eosi-api/commit/8ee9c69d551be71be2189c53736a854e2299c9e8)
- Found output types that Prisma generated based on schema. Replaced custom made User type with Prisma generated type
2. [Fix typo when using environment variable related to JWT](https://github.com/ahcock/eosi-api/commit/94a379e2275ced9d18eaebf1cf3028479d4608dc)