### PR TITLE
Make env config dynamic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,14 @@
         "express": "^4.18.3",
         "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
+        "lodash.merge": "^4.6.2",
         "morgan": "^1.10.0"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.6",
+        "@types/lodash.merge": "^4.6.9",
         "@types/node": "^20.11.25",
         "nodemon": "^3.1.0",
         "prisma": "^5.10.2",
@@ -250,6 +252,21 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.merge": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
+      "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
       }
     },
     "node_modules/@types/mime": {
@@ -1264,6 +1281,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "express": "^4.18.3",
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
+    "lodash.merge": "^4.6.2",
     "morgan": "^1.10.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
+    "@types/lodash.merge": "^4.6.9",
     "@types/node": "^20.11.25",
     "nodemon": "^3.1.0",
     "prisma": "^5.10.2",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,27 @@
+import merge from "lodash.merge";
+
+process.env.NODE_ENV = process.env.NODE_ENV || "development";
+
+const stage = process.env.STAGE || "local";
+
+let envConfig;
+
+if (stage === "production") {
+  envConfig = require("./prod").default;
+} else if (stage === "testing") {
+  envConfig = require("./testing").default;
+} else {
+  envConfig = require("./local").default;
+}
+
+const defaultConfig = {
+  stage,
+  env: process.env.NODE_ENV,
+  port: 3001,
+  secret: {
+    jwt: process.env.JWT_SECRET,
+    dbUrl: process.env.DATABASE_URL,
+  },
+};
+
+export default merge(defaultConfig, envConfig);

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -1,0 +1,3 @@
+export default {
+  port: 3001,
+};

--- a/src/config/prod.ts
+++ b/src/config/prod.ts
@@ -1,0 +1,3 @@
+export default {
+  port: 5002,
+};

--- a/src/config/testing.ts
+++ b/src/config/testing.ts
@@ -1,0 +1,3 @@
+export default {
+  port: process.env.PORT,
+};

--- a/src/config/testing.ts
+++ b/src/config/testing.ts
@@ -1,3 +1,1 @@
-export default {
-  port: process.env.PORT,
-};
+export default {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
-import * as dotenv from 'dotenv'
-dotenv.config()
+import * as dotenv from "dotenv";
+dotenv.config();
+import config from "./config";
 
 import app from "./server";
 
-app.listen(3001, () => {
-  console.log("http://localhost:3001 에 서버가 돌고 있어요!");
+app.listen(config.port, () => {
+  console.log(`http://localhost:${config.port} 에 서버가 돌고 있어요!`);
 });


### PR DESCRIPTION
## Make env config dynamic based on STAGE flag

usage example
```bash
STAGE=production npm run dev
```

- this config choose corresponding config file and override default env config at config/index.ts

## Install `lodash.merge` module

- use `lodash.merge` module to merge `default env config` and `custom env config` easier.